### PR TITLE
Add DragonProxy

### DIFF
--- a/applications/Proxies/DragonProxy.json
+++ b/applications/Proxies/DragonProxy.json
@@ -1,0 +1,13 @@
+{
+    "recommended": false,
+    "abandoned": false,
+    "external": true,
+    "url": "https:\/\/github.com\/DragonetMC\/DragonProxy",
+    "name": "DragonProxy",
+    "category": "Proxies",
+    "officialLinks": {},
+    "versionRegex": [
+        "\/[a-zA-Z]+-([0-9.]+).*\/",
+        "\/.*(latest).*\/"
+    ]
+}


### PR DESCRIPTION
DragonProxy is a proxy made to allow **Minecraft: Bedrock** clients to connect to **Minecraft: Java Edition** servers.